### PR TITLE
Refactor Code as per PEP8 guidelines

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,38 +1,43 @@
+import uuid
+
 from django.db import models
 from django.contrib.auth.models import User
 from django.core.validators import (
     ProhibitNullCharactersValidator,
 )
 
-import uuid
-
 # Create your models here.
 
+
 class Organization(models.Model):
-    user = models.OneToOneField(User, on_delete = models.CASCADE)
-    name = models.CharField(max_length = 100, validators = [ProhibitNullCharactersValidator])
-
-    def __str__ (self):
-        return self.name
-
-class Student(models.Model):
-    user = models.OneToOneField(User, on_delete = models.CASCADE)
-    name = models.CharField(max_length = 100, validators = [ProhibitNullCharactersValidator])
-
-    # fields for account activation
-    activation_key = models.CharField(max_length = 255, default = 1)
-    email_validated = models.BooleanField(default = False)
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100,
+                            validators=[ProhibitNullCharactersValidator])
 
     def __str__(self):
         return self.name
 
-class Certificate(models.Model):
-    id = models.UUIDField(unique = True, default = uuid.uuid4, primary_key = True)
-    student = models.ForeignKey(Student, on_delete = models.CASCADE)
-    issuing_organization = models.ForeignKey(Organization, on_delete = models.CASCADE)
 
-    date = models.DateField(auto_now_add = True)
-    issued_for = models.CharField(max_length = 256)
+class Student(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100,
+                            validators=[ProhibitNullCharactersValidator])
+
+    # fields for account activation
+    activation_key = models.CharField(max_length=255, default=1)
+    email_validated = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.name
+
+
+class Certificate(models.Model):
+    id = models.UUIDField(unique=True, default=uuid.uuid4, primary_key=True)
+    student = models.ForeignKey(Student, on_delete=models.CASCADE)
+    issuing_organization = models.ForeignKey(Organization,
+                                             on_delete=models.CASCADE)
+    date = models.DateField(auto_now_add=True)
+    issued_for = models.CharField(max_length=256)
 
     class Meta:
         permissions = (

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -2,13 +2,14 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework import permissions
 
+
 class CanIssueCertificate(permissions.BasePermission):
     @classmethod
     def has_permission(cls, request, view):
         user = request.user
         if user:
             try:
-                return user.user_permissions.get(codename = 'can_issue_certificate')
+                return user.user_permissions.get(codename='can_issue_certificate')
             except ObjectDoesNotExist:
                 pass
         return False

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,13 +1,14 @@
 from django.contrib.auth.models import User
-
 from rest_framework import serializers
 
 from api import models
+
 
 class StudentBasicSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Student
         fields = ('name',)
+
 
 class UserBasicSerializer(serializers.ModelSerializer):
     student = StudentBasicSerializer()
@@ -16,10 +17,12 @@ class UserBasicSerializer(serializers.ModelSerializer):
         model = User
         fields = ('username', 'email', 'student')
 
+
 class OrganisationBasicSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Organization
         fields = ('name',)
+
 
 class UserOrganizationBasicSerializer(serializers.ModelSerializer):
     organization = OrganisationBasicSerializer()
@@ -27,6 +30,7 @@ class UserOrganizationBasicSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('username', 'email', 'organization')
+
 
 class CertificateSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/views.py
+++ b/api/views.py
@@ -15,18 +15,20 @@ from api import (
 
 
 class StudentDetail(generics.RetrieveAPIView):
-    queryset = User.objects.exclude(student = None)
+    queryset = User.objects.exclude(student=None)
     model = User
     serializer_class = serializers.UserBasicSerializer
 
     permission_classes = (permissions.IsAdminUser,)
+
 
 class StudentList(generics.ListAPIView):
-    queryset = User.objects.exclude(student = None)
+    queryset = User.objects.exclude(student=None)
     model = User
     serializer_class = serializers.UserBasicSerializer
 
     permission_classes = (permissions.IsAdminUser,)
+
 
 class CertificateList(generics.ListAPIView):
     model = models.Certificate
@@ -40,7 +42,9 @@ class CertificateDetail(generics.RetrieveAPIView):
     serializer_class = serializers.CertificateDetailSerializer
 
     def get_queryset(self):
-        return models.Certificate.objects.filter(student = self.request.user.student).exclude(student = None)
+        return models.Certificate.objects. \
+                filter(student=self.request.user.student).exclude(student=None)
+
 
 class CertificateCreate(generics.CreateAPIView):
     model = models.Certificate

--- a/certificate_generator/settings.py
+++ b/certificate_generator/settings.py
@@ -1,7 +1,10 @@
-import os
-from decouple import config
-import dj_database_url
 import datetime
+import os
+
+import dj_database_url
+
+from decouple import config
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -14,9 +17,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config('DEBUG', cast = bool , default = True)
+DEBUG = config('DEBUG', cast=bool, default=True)
 
-ALLOWED_HOSTS = [ host.strip() for host in config('ALLOWED_HOSTS', default = '').split(',') ]
+ALLOWED_HOSTS = [host.strip() for host in
+                 config('ALLOWED_HOSTS', default='').split(',')]
 
 
 # Application definition

--- a/certificate_generator/wsgi.py
+++ b/certificate_generator/wsgi.py
@@ -11,6 +11,8 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'certificate_generator.settings')
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+                      'certificate_generator.settings')
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,8 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'certificate_generator.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+                          'certificate_generator.settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
Multiple files with valid cases to be handled,
   1. line space added between before `Class`
   2. additional space truncated both sides of `=`
   3. 79 character limit enforced (but few exceptions)

Additionally in few files the imports in proper order were added,
   1. First the python inbuilt libraries
   2. Third party libraries
   3. Package modules

! The Few Exceptions for PEP8 which I feel could overdo it !
   1. The migration auto created API files should not be formatted.
   2. settings.py - module names are above 79 but formatting them would look like overdoing it
   3. permissions.py - bit over 79 but doesn't look like needs formatting

Resolves PEP8 formatting  #18