### PR TITLE
Additional PEP8 refactoring - 2

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,38 +1,43 @@
+import uuid
+
 from django.db import models
 from django.contrib.auth.models import User
 from django.core.validators import (
     ProhibitNullCharactersValidator,
 )
 
-import uuid
-
 # Create your models here.
 
+
 class Organization(models.Model):
-    user = models.OneToOneField(User, on_delete = models.CASCADE)
-    name = models.CharField(max_length = 100, validators = [ProhibitNullCharactersValidator])
-
-    def __str__ (self):
-        return self.name
-
-class Student(models.Model):
-    user = models.OneToOneField(User, on_delete = models.CASCADE)
-    name = models.CharField(max_length = 100, validators = [ProhibitNullCharactersValidator])
-
-    # fields for account activation
-    activation_key = models.CharField(max_length = 255, default = 1)
-    email_validated = models.BooleanField(default = False)
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100,
+                            validators=[ProhibitNullCharactersValidator])
 
     def __str__(self):
         return self.name
 
-class Certificate(models.Model):
-    id = models.UUIDField(unique = True, default = uuid.uuid4, primary_key = True)
-    student = models.ForeignKey(Student, on_delete = models.CASCADE)
-    issuing_organization = models.ForeignKey(Organization, on_delete = models.CASCADE)
 
-    date = models.DateField(auto_now_add = True)
-    issued_for = models.CharField(max_length = 256)
+class Student(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    name = models.CharField(max_length=100,
+                            validators=[ProhibitNullCharactersValidator])
+
+    # fields for account activation
+    activation_key = models.CharField(max_length=255, default=1)
+    email_validated = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.name
+
+
+class Certificate(models.Model):
+    id = models.UUIDField(unique=True, default=uuid.uuid4, primary_key=True)
+    student = models.ForeignKey(Student, on_delete=models.CASCADE)
+    issuing_organization = models.ForeignKey(Organization,
+                                             on_delete=models.CASCADE)
+    date = models.DateField(auto_now_add=True)
+    issued_for = models.CharField(max_length=256)
 
     class Meta:
         permissions = (

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -2,13 +2,14 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from rest_framework import permissions
 
+
 class CanIssueCertificate(permissions.BasePermission):
     @classmethod
     def has_permission(cls, request, view):
         user = request.user
         if user:
             try:
-                return user.user_permissions.get(codename = 'can_issue_certificate')
+                return user.user_permissions.get(codename='can_issue_certificate')
             except ObjectDoesNotExist:
                 pass
         return False

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -37,10 +37,11 @@ class CertificateSerializer(serializers.ModelSerializer):
         model = models.Certificate
         fields = ('issued_for', 'student', 'issuing_organization')
 
+
 class CertificateDetailSerializer(CertificateSerializer):
     student = StudentBasicSerializer()
     issuing_organization = OrganisationBasicSerializer()
 
     class Meta:
         model = models.Certificate
-        fields = ('id' ,'issued_for', 'student', 'issuing_organization')
+        fields = ('id', 'issued_for', 'student', 'issuing_organization')

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,13 +1,14 @@
 from django.contrib.auth.models import User
-
 from rest_framework import serializers
 
 from api import models
+
 
 class StudentBasicSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Student
         fields = ('name',)
+
 
 class UserBasicSerializer(serializers.ModelSerializer):
     student = StudentBasicSerializer()
@@ -16,10 +17,12 @@ class UserBasicSerializer(serializers.ModelSerializer):
         model = User
         fields = ('username', 'email', 'student')
 
+
 class OrganisationBasicSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Organization
         fields = ('name',)
+
 
 class UserOrganizationBasicSerializer(serializers.ModelSerializer):
     organization = OrganisationBasicSerializer()
@@ -27,6 +30,7 @@ class UserOrganizationBasicSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('username', 'email', 'organization')
+
 
 class CertificateSerializer(serializers.ModelSerializer):
     class Meta:

--- a/api/views.py
+++ b/api/views.py
@@ -15,18 +15,20 @@ from api import (
 
 
 class StudentDetail(generics.RetrieveAPIView):
-    queryset = User.objects.exclude(student = None)
+    queryset = User.objects.exclude(student=None)
     model = User
     serializer_class = serializers.UserBasicSerializer
 
     permission_classes = (permissions.IsAdminUser,)
+
 
 class StudentList(generics.ListAPIView):
-    queryset = User.objects.exclude(student = None)
+    queryset = User.objects.exclude(student=None)
     model = User
     serializer_class = serializers.UserBasicSerializer
 
     permission_classes = (permissions.IsAdminUser,)
+
 
 class CertificateList(generics.ListAPIView):
     model = models.Certificate
@@ -40,7 +42,9 @@ class CertificateDetail(generics.RetrieveAPIView):
     serializer_class = serializers.CertificateDetailSerializer
 
     def get_queryset(self):
-        return models.Certificate.objects.filter(student = self.request.user.student).exclude(student = None)
+        return models.Certificate.objects. \
+                filter(student=self.request.user.student).exclude(student=None)
+
 
 class CertificateCreate(generics.CreateAPIView):
     model = models.Certificate

--- a/api/views.py
+++ b/api/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import render
 from django.contrib.auth.models import User
 
 from rest_framework.response import Response
@@ -35,7 +34,9 @@ class CertificateList(generics.ListAPIView):
     serializer_class = serializers.CertificateDetailSerializer
 
     def get_queryset(self):
-        return models.Certificate.objects.filter(student = self.request.user.student).exclude(student = None)
+        return models.Certificate.objects.filter(student=self.request.user.student). \
+                                          exclude(student=None)
+
 
 class CertificateDetail(generics.RetrieveAPIView):
     model = models.Certificate
@@ -54,8 +55,8 @@ class CertificateCreate(generics.CreateAPIView):
     def create(self, request, *args, **kwargs):
         data = request.data.copy()
         data['issuing_organization'] = request.user.organization.pk
-        serializer = self.serializer_class(data = data)
-        serializer.is_valid(raise_exception = True)
+        serializer = self.serializer_class(data=data)
+        serializer.is_valid(raise_exception=True)
         serializer.save()
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/certificate_generator/settings.py
+++ b/certificate_generator/settings.py
@@ -99,7 +99,8 @@ else:
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        'NAME': 'django.contrib.auth.password_validation.'
+                'UserAttributeSimilarityValidator',
     },
     {
         'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',

--- a/certificate_generator/settings.py
+++ b/certificate_generator/settings.py
@@ -1,7 +1,10 @@
-import os
-from decouple import config
-import dj_database_url
 import datetime
+import os
+
+import dj_database_url
+
+from decouple import config
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -14,9 +17,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = config('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config('DEBUG', cast = bool , default = True)
+DEBUG = config('DEBUG', cast=bool, default=True)
 
-ALLOWED_HOSTS = [ host.strip() for host in config('ALLOWED_HOSTS', default = '').split(',') ]
+ALLOWED_HOSTS = [host.strip() for host in
+                 config('ALLOWED_HOSTS', default='').split(',')]
 
 
 # Application definition

--- a/certificate_generator/wsgi.py
+++ b/certificate_generator/wsgi.py
@@ -11,6 +11,8 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'certificate_generator.settings')
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+                      'certificate_generator.settings')
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,8 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'certificate_generator.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+                          'certificate_generator.settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
After my previous fix for pep8 refactoring.

While I was working on next task I could see issues as result of earlier merge.

I provided fix and we can look to place this in continous process.

Command I executed was 
`$ pycodestyle --max-line-length=90 --exclude=./api/migrations/* .`

As previously stated, migrations directory is auto generated with code so excluding that always!

Prior in Previous pep formatting, I had used 79 character limit.
I feel 90 would be more appropriate but let maintainers confirm.

References #18 